### PR TITLE
Add AWS infrastructure templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # はじめに
-このリポジトリはMosaicBERTの日本語事前学習モデルを構築するための環境です。
-AWSに環境を構築した上で、主にLLM-jpのデータセットを用いて、MosaicBERTの事前学習を行います。
+このリポジトリは MosaicBERT の日本語事前学習を行うための環境を提供します。
+CloudFormation テンプレートと起動用スクリプトにより、AWS 上で必要なリソースを作成できます。
+
+## 使い方
+1. CloudFormation テンプレート `cloudformation/mosaicbert_infra.yaml` をデプロイします。
+   ```bash
+   aws cloudformation create-stack \
+     --stack-name mosaicbert-stack \
+     --template-body file://cloudformation/mosaicbert_infra.yaml \
+     --capabilities CAPABILITY_NAMED_IAM
+   ```
+
+2. 学習を開始する場合は `scripts/start_training.sh` を実行します。
+   AMI ID やキーペア名はスクリプト内で設定してください。
+
+3. 学習後は EC2 インスタンスと FSx ファイルシステムを削除してコストを抑えます。
+
+テンプレートとスクリプトは一例です。必要に応じてリージョンやパラメータを変更してください。

--- a/cloudformation/mosaicbert_infra.yaml
+++ b/cloudformation/mosaicbert_infra.yaml
@@ -1,0 +1,170 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Infrastructure for MosaicBERT training
+
+Parameters:
+  VpcCidr:
+    Type: String
+    Default: 10.0.0.0/16
+  PublicSubnetCidr:
+    Type: String
+    Default: 10.0.0.0/24
+  KeyName:
+    Type: AWS::EC2::KeyPair::KeyName
+    Description: EC2 KeyPair for SSH access
+
+Resources:
+  MosaicVpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !Ref VpcCidr
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        - Key: Name
+          Value: mosaicbert-vpc
+
+  PublicSubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref MosaicVpc
+      CidrBlock: !Ref PublicSubnetCidr
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: mosaicbert-public-subnet
+
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+
+  AttachGateway:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      InternetGatewayId: !Ref InternetGateway
+      VpcId: !Ref MosaicVpc
+
+  RouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref MosaicVpc
+
+  PublicRoute:
+    Type: AWS::EC2::Route
+    DependsOn: AttachGateway
+    Properties:
+      RouteTableId: !Ref RouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+
+  RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnet
+      RouteTableId: !Ref RouteTable
+
+  SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow SSH and FSx
+      VpcId: !Ref MosaicVpc
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 988
+          ToPort: 988
+          CidrIp: 0.0.0.0/0
+      SecurityGroupEgress:
+        - IpProtocol: -1
+          FromPort: -1
+          ToPort: -1
+          CidrIp: 0.0.0.0/0
+
+  DatasetBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: mosaicbert-datasets
+      LifecycleConfiguration:
+        Rules:
+          - Id: TransitionRule
+            Status: Enabled
+            Transitions:
+              - StorageClass: STANDARD_IA
+                TransitionInDays: 30
+              - StorageClass: GLACIER
+                TransitionInDays: 90
+
+  CheckpointBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: mosaicbert-checkpoints
+      LifecycleConfiguration:
+        Rules:
+          - Id: TransitionRule
+            Status: Enabled
+            Transitions:
+              - StorageClass: STANDARD_IA
+                TransitionInDays: 30
+              - StorageClass: GLACIER
+                TransitionInDays: 90
+
+  TrainingRepository:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: mosaicbert/training
+      LifecyclePolicy:
+        LifecyclePolicyText: |
+          {
+            "rules": [
+              {
+                "rulePriority": 1,
+                "description": "Keep last 3 images",
+                "selection": {
+                  "tagStatus": "any",
+                  "countType": "imageCountMoreThan",
+                  "countNumber": 3
+                },
+                "action": {"type": "expire"}
+              }
+            ]
+          }
+
+  InstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
+      Path: /
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonS3FullAccess
+        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+        - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+        - arn:aws:iam::aws:policy/AmazonFSxFullAccess
+
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Roles:
+        - !Ref InstanceRole
+
+Outputs:
+  VpcId:
+    Value: !Ref MosaicVpc
+  SubnetId:
+    Value: !Ref PublicSubnet
+  SecurityGroupId:
+    Value: !Ref SecurityGroup
+  InstanceProfile:
+    Value: !Ref InstanceProfile
+  DatasetBucket:
+    Value: !Ref DatasetBucket
+  CheckpointBucket:
+    Value: !Ref CheckpointBucket
+  RepositoryUri:
+    Value: !GetAtt TrainingRepository.RepositoryUri

--- a/scripts/start_training.sh
+++ b/scripts/start_training.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -euo pipefail
+
+# Parameters
+STACK_NAME="mosaicbert-stack"
+REGION="us-east-1"
+INSTANCE_TYPE="p5.48xlarge"
+AMI_ID="ami-1234567890abcdef0"  # replace with appropriate DLAMI or custom AMI
+KEY_NAME="your-keypair"         # replace with your key pair
+
+# Retrieve resources from CloudFormation stack
+VPC_ID=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --query 'Stacks[0].Outputs[?OutputKey==`VpcId`].OutputValue' --output text)
+SUBNET_ID=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --query 'Stacks[0].Outputs[?OutputKey==`SubnetId`].OutputValue' --output text)
+SG_ID=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --query 'Stacks[0].Outputs[?OutputKey==`SecurityGroupId`].OutputValue' --output text)
+PROFILE_ARN=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --query 'Stacks[0].Outputs[?OutputKey==`InstanceProfile`].OutputValue' --output text)
+
+# Create FSx for Lustre
+FILESYSTEM_ID=$(aws fsx create-file-system \
+  --region "$REGION" \
+  --file-system-type LUSTRE \
+  --storage-capacity 1200 \
+  --lustre-configuration ImportPath=s3://mosaicbert-datasets/ \
+  --subnet-ids "$SUBNET_ID" \
+  --security-group-ids "$SG_ID" \
+  --query 'FileSystem.FileSystemId' --output text)
+
+echo "Waiting for FSx to become available..."
+aws fsx wait file-system-available --file-system-id "$FILESYSTEM_ID" --region "$REGION"
+
+# Launch EC2 instance
+INSTANCE_ID=$(aws ec2 run-instances \
+  --region "$REGION" \
+  --image-id "$AMI_ID" \
+  --count 1 \
+  --instance-type "$INSTANCE_TYPE" \
+  --key-name "$KEY_NAME" \
+  --subnet-id "$SUBNET_ID" \
+  --security-group-ids "$SG_ID" \
+  --iam-instance-profile Arn="$PROFILE_ARN" \
+  --block-device-mappings '[{"DeviceName":"/dev/xvda","Ebs":{"VolumeSize":200}}]' \
+  --tag-specifications 'ResourceType=instance,Tags=[{Key=Name,Value=mosaicbert-training}]' \
+  --query 'Instances[0].InstanceId' --output text)
+
+echo "Instance $INSTANCE_ID launched"
+echo "Waiting for instance to be running..."
+aws ec2 wait instance-running --instance-ids "$INSTANCE_ID" --region "$REGION"
+
+PUBLIC_IP=$(aws ec2 describe-instances --instance-ids "$INSTANCE_ID" --query 'Reservations[0].Instances[0].PublicIpAddress' --output text --region "$REGION")
+echo "Connect with: ssh -i <path-to-key> ec2-user@$PUBLIC_IP"
+
+# To terminate:
+# aws ec2 terminate-instances --instance-ids "$INSTANCE_ID" --region "$REGION"
+# aws fsx delete-file-system --file-system-id "$FILESYSTEM_ID" --region "$REGION"


### PR DESCRIPTION
## Summary
- provide CloudFormation template for MosaicBERT training environment
- add helper script to start training with FSx and EC2
- update README with usage instructions

## Testing
- `aws cloudformation validate-template` *(fails: `aws` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e0162c9d883288b7bc363996f4f25