### PR TITLE
Add data pipeline scripts for step3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/scripts/step03_data_pipeline/adjust_domain_ratio.py
+++ b/scripts/step03_data_pipeline/adjust_domain_ratio.py
@@ -1,0 +1,42 @@
+import argparse
+import json
+from collections import defaultdict
+
+
+NEWS_DOMAINS = {'news', 'blog'}
+
+
+def adjust_ratio(input_path: str, output_path: str, max_news_ratio: float) -> None:
+    counts = defaultdict(int)
+    lines = []
+    with open(input_path, 'r', encoding='utf-8') as f:
+        for line in f:
+            obj = json.loads(line)
+            domain = obj.get('domain', 'other')
+            counts[domain] += 1
+            lines.append(obj)
+
+    total = len(lines)
+    allowed_news = int(total * max_news_ratio)
+
+    news_kept = 0
+    with open(output_path, 'w', encoding='utf-8') as f:
+        for obj in lines:
+            if obj.get('domain') in NEWS_DOMAINS:
+                if news_kept >= allowed_news:
+                    continue
+                news_kept += 1
+            f.write(json.dumps(obj, ensure_ascii=False) + '\n')
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--input', required=True, help='JSONL file with domain field')
+    p.add_argument('--output', required=True)
+    p.add_argument('--max_news_ratio', type=float, default=0.3)
+    args = p.parse_args()
+    adjust_ratio(args.input, args.output, args.max_news_ratio)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/step03_data_pipeline/convert_to_mds.py
+++ b/scripts/step03_data_pipeline/convert_to_mds.py
@@ -1,0 +1,27 @@
+import argparse
+import subprocess
+
+
+def convert_text_to_mds(input_dir: str, output_dir: str, shard_size: str = '64MiB') -> None:
+    cmd = [
+        'streaming', 'convert', 'text',
+        '--input', input_dir,
+        '--output', output_dir,
+        '--compression', 'zstd',
+        '--size-limit', shard_size,
+        '--drop_dedupe'
+    ]
+    subprocess.check_call(cmd)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--input_dir', required=True)
+    p.add_argument('--output_dir', required=True)
+    p.add_argument('--shard_size', default='64MiB')
+    args = p.parse_args()
+    convert_text_to_mds(args.input_dir, args.output_dir, args.shard_size)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/step03_data_pipeline/crawl_aozora_diet.py
+++ b/scripts/step03_data_pipeline/crawl_aozora_diet.py
@@ -1,0 +1,51 @@
+import argparse
+import os
+import requests
+from bs4 import BeautifulSoup
+
+AOZORA_LIST = 'https://www.aozora.gr.jp/index_pages/person_all.html'
+DIET_SEARCH = 'https://kokkai.ndl.go.jp/api/speech?record_id='  # placeholder
+
+
+def fetch_url(url: str) -> str:
+    r = requests.get(url)
+    r.raise_for_status()
+    return r.text
+
+
+def crawl_aozora(out_dir: str) -> None:
+    html = fetch_url(AOZORA_LIST)
+    soup = BeautifulSoup(html, 'html.parser')
+    os.makedirs(out_dir, exist_ok=True)
+    for link in soup.select('a[href$=".txt"]'):
+        url = link['href']
+        filename = os.path.join(out_dir, os.path.basename(url))
+        text = fetch_url(url)
+        with open(filename, 'w', encoding='shift_jis') as f:
+            f.write(text)
+
+
+def crawl_diet(record_ids: list[str], out_dir: str) -> None:
+    os.makedirs(out_dir, exist_ok=True)
+    for rec_id in record_ids:
+        url = f"{DIET_SEARCH}{rec_id}"
+        text = fetch_url(url)
+        path = os.path.join(out_dir, f"{rec_id}.xml")
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(text)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--aozora_dir', required=True)
+    p.add_argument('--diet_dir', required=True)
+    p.add_argument('--diet_ids', nargs='*', default=[])
+    args = p.parse_args()
+
+    crawl_aozora(args.aozora_dir)
+    if args.diet_ids:
+        crawl_diet(args.diet_ids, args.diet_dir)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/step03_data_pipeline/deduplicate.py
+++ b/scripts/step03_data_pipeline/deduplicate.py
@@ -1,0 +1,39 @@
+import argparse
+import os
+from datasketch import MinHash, MinHashLSH
+from langdetect import detect
+
+
+def minhash(text: str, num_perm: int = 128) -> MinHash:
+    m = MinHash(num_perm=num_perm)
+    for word in text.split():
+        m.update(word.encode('utf-8'))
+    return m
+
+
+def dedupe_file(input_path: str, output_path: str) -> None:
+    seen_lsh = MinHashLSH(threshold=0.9, num_perm=128)
+    with open(input_path, 'r', encoding='utf-8') as fin, \
+            open(output_path, 'w', encoding='utf-8') as fout:
+        for idx, line in enumerate(fin):
+            try:
+                lang = detect(line)
+            except Exception:
+                continue
+            if lang != 'ja':
+                continue
+            mh = minhash(line)
+            if not seen_lsh.insert(str(idx), mh):
+                fout.write(line)
+
+
+def main():
+    p = argparse.ArgumentParser(description='Deduplicate and filter non-Japanese text')
+    p.add_argument('--input', required=True)
+    p.add_argument('--output', required=True)
+    args = p.parse_args()
+    dedupe_file(args.input, args.output)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/step03_data_pipeline/download_llm_jp.py
+++ b/scripts/step03_data_pipeline/download_llm_jp.py
@@ -1,0 +1,35 @@
+import argparse
+import boto3
+import os
+from urllib.parse import urlparse
+
+
+def download_llm_jp(s3_uri: str, local_dir: str) -> None:
+    """Recursively download a dataset from an S3 URI."""
+    parsed = urlparse(s3_uri)
+    if parsed.scheme != 's3':
+        raise ValueError(f"Expect s3:// URI, got: {s3_uri}")
+    bucket = parsed.netloc
+    prefix = parsed.path.lstrip('/')
+    s3 = boto3.client('s3')
+
+    paginator = s3.get_paginator('list_objects_v2')
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get('Contents', []):
+            key = obj['Key']
+            rel_path = os.path.relpath(key, prefix)
+            local_path = os.path.join(local_dir, rel_path)
+            os.makedirs(os.path.dirname(local_path), exist_ok=True)
+            s3.download_file(bucket, key, local_path)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Download LLM-jp v4 dataset from S3')
+    parser.add_argument('--s3_uri', required=True, help='S3 URI of dataset root')
+    parser.add_argument('--out_dir', required=True, help='Local output directory')
+    args = parser.parse_args()
+    download_llm_jp(args.s3_uri, args.out_dir)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/step03_data_pipeline/download_wikipedia.py
+++ b/scripts/step03_data_pipeline/download_wikipedia.py
@@ -1,0 +1,32 @@
+import argparse
+import os
+import requests
+
+
+BASE_URL = 'https://dumps.wikimedia.org/jawiki/'
+
+
+def download_dump(date: str, out_dir: str) -> None:
+    filename = f'jawiki-{date}-pages-articles.xml.bz2'
+    url = f"{BASE_URL}{date}/{filename}"
+    os.makedirs(out_dir, exist_ok=True)
+    out_path = os.path.join(out_dir, filename)
+    with requests.get(url, stream=True) as r:
+        r.raise_for_status()
+        with open(out_path, 'wb') as f:
+            for chunk in r.iter_content(chunk_size=8192):
+                if chunk:
+                    f.write(chunk)
+    print(f"Downloaded {out_path}")
+
+
+def main():
+    p = argparse.ArgumentParser(description='Download Wikipedia JA dump')
+    p.add_argument('--date', required=True, help='Dump date (YYYYMMDD)')
+    p.add_argument('--out_dir', required=True)
+    args = p.parse_args()
+    download_dump(args.date, args.out_dir)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/step03_data_pipeline/extract_cc100.py
+++ b/scripts/step03_data_pipeline/extract_cc100.py
@@ -1,0 +1,22 @@
+import argparse
+from datasets import load_dataset
+
+
+def download_cc100(language: str, out_dir: str) -> None:
+    ds = load_dataset('cc100', language, split='train', streaming=True)
+    with open(out_dir, 'w', encoding='utf-8') as f:
+        for sample in ds:
+            f.write(sample['text'] + '\n')
+    print(f"Saved CC100-{language} to {out_dir}")
+
+
+def main():
+    p = argparse.ArgumentParser(description='Extract CC100 subset')
+    p.add_argument('--lang', default='ja')
+    p.add_argument('--out_file', required=True)
+    args = p.parse_args()
+    download_cc100(args.lang, args.out_file)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/step03_data_pipeline/sample_quality.py
+++ b/scripts/step03_data_pipeline/sample_quality.py
@@ -1,0 +1,36 @@
+import argparse
+import pandas as pd
+
+
+def sample_top_tokens(csv_path: str, token_column: str, score_column: str, target_tokens: int, out_csv: str) -> None:
+    """Sample rows from quality metadata until target token count reached."""
+    df = pd.read_csv(csv_path)
+    df = df.sort_values(score_column, ascending=False)
+
+    sampled_rows = []
+    total_tokens = 0
+    for _, row in df.iterrows():
+        tokens = int(row[token_column])
+        sampled_rows.append(row)
+        total_tokens += tokens
+        if total_tokens >= target_tokens:
+            break
+
+    out_df = pd.DataFrame(sampled_rows)
+    out_df.to_csv(out_csv, index=False)
+    print(f"Sampled {len(out_df)} rows => {total_tokens} tokens")
+
+
+def main():
+    p = argparse.ArgumentParser(description='Sample high quality subset')
+    p.add_argument('--csv', required=True, help='Path to quality metadata CSV')
+    p.add_argument('--token_column', default='num_tokens')
+    p.add_argument('--score_column', default='quality_score')
+    p.add_argument('--target_tokens', type=int, required=True)
+    p.add_argument('--out_csv', required=True)
+    args = p.parse_args()
+    sample_top_tokens(args.csv, args.token_column, args.score_column, args.target_tokens, args.out_csv)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/step03_data_pipeline/upload_to_s3.py
+++ b/scripts/step03_data_pipeline/upload_to_s3.py
@@ -1,0 +1,32 @@
+import argparse
+import os
+import boto3
+from urllib.parse import urlparse
+
+
+def upload_directory(local_dir: str, s3_uri: str) -> None:
+    parsed = urlparse(s3_uri)
+    if parsed.scheme != 's3':
+        raise ValueError('s3_uri must start with s3://')
+    bucket = parsed.netloc
+    prefix = parsed.path.lstrip('/')
+    s3 = boto3.client('s3')
+    for root, _, files in os.walk(local_dir):
+        for fname in files:
+            path = os.path.join(root, fname)
+            rel = os.path.relpath(path, local_dir)
+            key = os.path.join(prefix, rel)
+            s3.upload_file(path, bucket, key)
+            print(f"Uploaded {path} -> s3://{bucket}/{key}")
+
+
+def main():
+    p = argparse.ArgumentParser(description='Upload dataset to S3')
+    p.add_argument('--local_dir', required=True)
+    p.add_argument('--s3_uri', required=True)
+    args = p.parse_args()
+    upload_directory(args.local_dir, args.s3_uri)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add Python scripts implementing data pipeline tasks (3-1 to 3-9)
- organize them under `scripts/step03_data_pipeline`
- ignore Python cache files via `.gitignore`

## Testing
- `python -m py_compile scripts/step03_data_pipeline/*.py`


------
https://chatgpt.com/codex/tasks/task_e_686e32e86ee48328b16f724105049ebd